### PR TITLE
fix assert transformers._import_structure llama

### DIFF
--- a/train/finetune.py
+++ b/train/finetune.py
@@ -13,7 +13,7 @@ import transformers
 import json
 
 assert (
-    "LlamaTokenizer" in transformers._import_structure["models.llama"]
+    "LlamaConfig" in transformers._import_structure["models.llama"]
 ), "LLaMA is now in HuggingFace's main branch.\nPlease reinstall it: pip uninstall transformers && pip install git+https://github.com/huggingface/transformers.git"
 from transformers import LlamaForCausalLM, LlamaTokenizer
 from transformers import AutoModelForCausalLM, AutoTokenizer


### PR DESCRIPTION
because the huggingface main is not always has "LlamaTokenizer" in [transformers._import_structure["models.llama"]](https://github.com/huggingface/transformers/blob/a55a822adf2c259d08ed532f8540e61129460b5b/src/transformers/__init__.py#L680) but "LlamaConfig" is [fixed](https://github.com/huggingface/transformers/blob/a55a822adf2c259d08ed532f8540e61129460b5b/src/transformers/__init__.py#L351)