### PR TITLE
修正final model保存问题

### DIFF
--- a/train/main.py
+++ b/train/main.py
@@ -386,19 +386,19 @@ def main():
 
         model.tput_timer.update_epoch_count()
 
-        if args.output_dir is not None:
-            print_rank_0('saving the final model ...', args.global_rank)#It will overwrite the last epoch model
-            model = convert_lora_to_linear_layer(model)
+    if args.output_dir is not None:
+        print_rank_0('saving the final model ...', args.global_rank)#It will overwrite the last epoch model
+        model = convert_lora_to_linear_layer(model)
 
-            if args.global_rank == 0:
-                save_hf_format(model, tokenizer, args)
+        if args.global_rank == 0:
+            save_hf_format(model, tokenizer, args)
 
-            if args.zero_stage == 3:
-                # For zero stage 3, each gpu only has a part of the model, so we need a special save function
-                save_zero_three_model(model,
-                                    args.global_rank,
-                                    args.output_dir,
-                                    zero_stage=args.zero_stage)
+        if args.zero_stage == 3:
+            # For zero stage 3, each gpu only has a part of the model, so we need a special save function
+            save_zero_three_model(model,
+                                args.global_rank,
+                                args.output_dir,
+                                zero_stage=args.zero_stage)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
final model应该在所有epoch跑完再进行保存，但现在是在第一个epoch训完就进行了保存，并且调用了`convert_lora_to_linear_layer`函数，导致`fuse_lora=True`。

`DeepSpeed-Chat`也是在所有epoch跑完才保存的final model，参见[https://github.com/microsoft/DeepSpeedExamples/blob/a5d4dc12828514ea7f427cd513665ba711dcd670/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/main.py#L327](https://github.com/microsoft/DeepSpeedExamples/blob/a5d4dc12828514ea7f427cd513665ba711dcd670/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/main.py#L327)