### PR TITLE
Update lora_config_bloom.json

### DIFF
--- a/train/configs/lora_config_bloom.json
+++ b/train/configs/lora_config_bloom.json
@@ -1,5 +1,5 @@
 {
-    "lora_r": 16,
+    "r": 16,
     "lora_alpha": 32,
     "lora_dropout": 0.05,
     "lora_target_modules": [


### PR DESCRIPTION
The `lora_r` should be changed to `r` since the parameters in `LoraConfig` is `r`

![Screen Shot 2023-05-12 at 3 17 13 PM](https://github.com/LianjiaTech/BELLE/assets/22190213/1fd234be-6401-42a4-878a-a6c7e5d50cb0)
