### PR TITLE
synchronize before creating output_dir

### DIFF
--- a/train/src/entry_point/pt_train.py
+++ b/train/src/entry_point/pt_train.py
@@ -201,6 +201,7 @@ def main():
                 f"Checkpoint detected, resuming training at {last_checkpoint}. To avoid this behavior, change "
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
+    torch.distributed.barrier()
 
     # Set seed before initializing model.
     set_seed(training_args.seed)

--- a/train/src/entry_point/rm_train.py
+++ b/train/src/entry_point/rm_train.py
@@ -6,6 +6,7 @@ import os
 import sys
 from typing import Any, Dict, List, Optional, Union
 
+import torch
 from accelerate import Accelerator
 from datasets import load_dataset
 from peft import LoraConfig, get_peft_model
@@ -374,6 +375,7 @@ def main():
                 f"Checkpoint detected, resuming training at {last_checkpoint}. To avoid this behavior, change "
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
+    torch.distributed.barrier()
 
     checkpoint = None
     if training_args.resume_from_checkpoint is not None:

--- a/train/src/entry_point/sft_train.py
+++ b/train/src/entry_point/sft_train.py
@@ -206,6 +206,7 @@ def main():
                 f"Checkpoint detected, resuming training at {last_checkpoint}. To avoid this behavior, change "
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
+    torch.distributed.barrier()
 
     # Set seed before initializing model.
     set_seed(training_args.seed)


### PR DESCRIPTION
In multiprocessing, log file may be created before other processes checking if `len(os.listdir(training_args.output_dir)) > 0`, and thus a `ValueError` will be raised.

Synchronizing between processes using `torch.distributed.barrier()` tackles this problem.